### PR TITLE
Added images with advises

### DIFF
--- a/src/BodyPage.jsx
+++ b/src/BodyPage.jsx
@@ -55,15 +55,24 @@ export default function BodyPage() {
               sostenible en el debate público y mejorar la seguridad de los
               ciclistas confiando en que se está más seguro cuando se está en
               grupo.<br></br>
-              Recorridos en bicicleta como Masa Crítica, con
-              cientos de participantes se llevó a cabo por primera vez en Estocolmo, Suecia en
-              la década de 1970.Pero las primeras celebraciones dentro de
-              la actual ola de la Masa Crítica tuvieron lugar en San Francisco
-              (Estados Unidos) en 1992. En un primer momento acudieron tan
-              sólo 58 personas, pero en menos de un año ya eran unos 500.
+              Recorridos en bicicleta como Masa Crítica, con cientos de
+              participantes se llevó a cabo por primera vez en Estocolmo, Suecia
+              en la década de 1970.Pero las primeras celebraciones dentro de la
+              actual ola de la Masa Crítica tuvieron lugar en San Francisco
+              (Estados Unidos) en 1992. En un primer momento acudieron tan sólo
+              58 personas, pero en menos de un año ya eran unos 500.
             </p>
           )}
-          {showQue && <p> </p>}
+          {showQue && <div className="imgs">
+            <img className="top" src="src/assets/images/suggestions/1.png"></img>
+            <img className="top" src="src/assets/images/suggestions/2.jpg"></img>
+            <img className="top" src="src/assets/images/suggestions/3.jpg"></img>
+            <img className="top" src="src/assets/images/suggestions/4.jpg"></img>
+            <img className="bot" src="src/assets/images/suggestions/5.jpg"></img>
+            <img className="bot" src="src/assets/images/suggestions/6.jpg"></img>
+            <img className="bot" src="src/assets/images/suggestions/7.jpg"></img>
+            <img className="bot" src="src/assets/images/suggestions/8.jpg"></img>
+            </div>}
           {showTal && (
             <p>
               {" "}

--- a/src/styles/BodyPage.css
+++ b/src/styles/BodyPage.css
@@ -4,6 +4,12 @@
   padding-right: 2rem;
   /* margin-top: 1.5rem; */
 }
+.imgs{
+  display: grid;
+  grid-template-columns: auto auto auto auto;
+  column-gap: 20px;
+  row-gap: 20px;
+}
 
 .list-content {
   background-color: whitesmoke;
@@ -12,14 +18,19 @@
  
   border-radius: 2rem;
   padding-right: 2rem;
-  margin-right: 13rem;
+  margin-right: 20rem;
   margin-top: 1rem;
 }
 .main {
   height: 14.4rem;
   display: flex;
   justify-content: space-between;
+  height: fit-content;
 }
 p{
   text-align: left;
+}
+.imgs>img{
+  width: 200px;
+  height: 300px;
 }


### PR DESCRIPTION
The images provided by 'critical mass Málaga' have been added to the web.

![Captura de pantalla 2023-11-02 201403](https://github.com/jahcuida/critical-mass/assets/105076467/762b1a78-60ad-472c-be7e-4d5c346bdc5f)

This has made me think about changing the left menu because I don't like the current structure after adding the images.

This PR closes #6 

